### PR TITLE
Corrected pairing address for resets.

### DIFF
--- a/src/arduino_homekit_server.cpp
+++ b/src/arduino_homekit_server.cpp
@@ -2329,7 +2329,7 @@ HAPStatus process_characteristics_update(const cJSON *j_ch, client_context_t *co
 
 	cJSON *j_events = cJSON_GetObjectItem(j_ch, "ev");
 	if (j_events) {
-		if (!(ch->permissions && homekit_permissions_notify)) {
+		if (!(ch->permissions & homekit_permissions_notify)) {
 			CLIENT_ERROR(context,
 					"Failed to set notification state for %d.%d: " "notifications are not supported",
 					aid, iid);

--- a/src/storage.c
+++ b/src/storage.c
@@ -152,7 +152,7 @@ int homekit_storage_reset_pairing_data() {
     bzero(blank,sizeof(blank));
 
     INFO("Formatting HomeKit storage at 0x%x", PAIRINGS_OFFSET);
-    if (!spiflash_write(PAIRINGS_OFFSET, blank, sizeof(blank))) {
+    if (!spiflash_write(PAIRINGS_ADDR, blank, sizeof(blank))) {
         ERROR("Failed to erase HomeKit pairing storage");
         return -1; // Fail case
     }


### PR DESCRIPTION
I think the address is invalid for the `homekit_storage_reset_pairing_data()` function.